### PR TITLE
chore: redirect markdown guide to homepage

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -22,10 +22,8 @@ export default defineConfig({
   },
 
   redirects: {
-    "/blog/04-markdown-syntax": {
-      status: 301,
-      destination: "/",
-    },
+    "/blog/04-markdown-syntax": "/",
+    "/blog/04-markdown-syntax/": "/",
   },
 
   adapter: vercel(),

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -21,5 +21,12 @@ export default defineConfig({
     },
   },
 
+  redirects: {
+    "/blog/04-markdown-syntax": {
+      status: 301,
+      destination: "/",
+    },
+  },
+
   adapter: vercel(),
 });

--- a/src/content/blog/04-markdown-syntax/index.mdx
+++ b/src/content/blog/04-markdown-syntax/index.mdx
@@ -2,6 +2,7 @@
 title: "Markdown syntax guide"
 description: "Get started writing content in Markdown."
 date: "2024-03-17"
+draft: true
 tag:
   - reference
 ---


### PR DESCRIPTION
## Summary
- hide `04-markdown-syntax` post by marking it as a draft
- redirect `/blog/04-markdown-syntax` to the homepage with a 301 status

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689132fa0b208322b2054e3cca5df605